### PR TITLE
Fix no options error

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,14 @@ var path = require('path');
 var client = require("./client");
 
 var NightmareBrowser = function (baseBrowserDecorator, args, config) {
+  const options = config.nightmareOptions || {};
   const file = path.join(__dirname, 'lib/browser.js');
   baseBrowserDecorator(this);
   this._start = function (url) {
     this._execCommand('node', [
       file,
       url,
-      JSON.stringify(config.nightmareOptions),
+      JSON.stringify(options),
     ]);
 
     this._process.stderr.on('data', function (data) {


### PR DESCRIPTION
Currently, karma-nightmare doesn't allow a configuration without `nightmareOptions` field.

```
13 02 2017 16:01:58.757:INFO [launcher]: Trying to start Nightmare again (1/2).
undefined:1
undefined
^

SyntaxError: Unexpected token u in JSON at position 0
    at Object.parse (native)
    at Object.<anonymous> (/Users/laco/Works/tmp/ng-nightmare-example/node_modules/karma-nightmare/lib/browser.js:3:22)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
```

I hope `{}` means that will use the default options. is it right?